### PR TITLE
Add: Proxy extension for HTTPBuilder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ test_video.mp4
 # old cli directories
 /tooling/cli.js
 /tooling/cli.rs
+.vscode/launch.json

--- a/core/tauri/Cargo.toml
+++ b/core/tauri/Cargo.toml
@@ -140,7 +140,7 @@ updater = [
   "dialog-ask",
   "fs-extract-api"
 ]
-http-api = [ "attohttpc" ]
+http-api = [ "attohttpc", "base64" ]
 http-multipart = [ "attohttpc/multipart-form", "reqwest/multipart" ]
 shell-open-api = [ "open", "regex", "tauri-macros/shell-scope" ]
 fs-extract-api = [ "zip" ]

--- a/core/tauri/src/api/error.rs
+++ b/core/tauri/src/api/error.rs
@@ -6,6 +6,9 @@
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
 pub enum Error {
+  /// Proxy Auth
+  #[error("Invalid Proxy Auth Configuarion")]
+  Auth,
   /// Command error.
   #[error("Command Error: {0}")]
   Command(String),

--- a/core/tauri/src/api/error.rs
+++ b/core/tauri/src/api/error.rs
@@ -82,6 +82,9 @@ pub enum Error {
   #[cfg_attr(doc_cfg, doc(cfg(feature = "cli")))]
   #[error("failed to parse CLI arguments: {0}")]
   ParseCliArguments(String),
+  /// No proxy server configuration
+  #[error("Proxy Server Configuarion not found")]
+  ProxyServer,
   /// Shell error.
   #[error("shell error: {0}")]
   Shell(String),

--- a/core/tauri/src/api/http.rs
+++ b/core/tauri/src/api/http.rs
@@ -928,7 +928,11 @@ impl Proxy {
   /// CUSTOM -> Use proxy.server fields
   fn convert(&self) -> crate::api::Result<ProxySettings>  {
     match self.mode {
-      Mode::NoProxy => Ok(ProxySettings::builder().build()),
+      Mode::NoProxy => {
+        let settings = ProxySettings::builder().build();
+        dbg!(&settings);
+        Ok(settings)
+      },
       Mode::Env => {
         let mut settings = ProxySettings::builder();
         if let Ok(disable) = env::var("NO_PROXY") {
@@ -943,13 +947,12 @@ impl Proxy {
 
         env_proxy_settings!("all_proxy", settings, [ http_proxy, https_proxy ]);
         env_proxy_settings!("ALL_PROXY", settings, [ http_proxy, https_proxy ]);
-        env_proxy_settings!("http_proxy", settings, [ http_proxy ]);
+        env_proxy_settings!("http_proxy", settings, [ http_proxy, https_proxy ]);
         env_proxy_settings!("https_proxy", settings, [ https_proxy ]);
-        env_proxy_settings!("HTTP_PROXY", settings, [ http_proxy ]);
+        env_proxy_settings!("HTTP_PROXY", settings, [ http_proxy, https_proxy ]);
         env_proxy_settings!("HTTPS_PROXY", settings, [ https_proxy ]);
 
         dbg!(&settings);
-
         Ok(settings.build())
        },
       Mode::Custom => {

--- a/core/tauri/src/api/http.rs
+++ b/core/tauri/src/api/http.rs
@@ -772,6 +772,7 @@ mod test {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Proxy {
   /// Proxy type
+  #[serde(rename = "type")]
   pub mode: Mode,
   /// Configuration settings
   pub server: Option<Server>

--- a/core/tauri/src/api/http.rs
+++ b/core/tauri/src/api/http.rs
@@ -941,6 +941,8 @@ impl Proxy {
           };
           // Build host URL
           let mut host = Url::parse(&server.host)?;
+          host.set_scheme(&server.protocol)
+            .map_err(|_| crate::api::Error::Url(url::ParseError::EmptyHost))?;
           host.set_port(Some(port))
             .map_err(|_| crate::api::Error::Url(url::ParseError::InvalidPort))?;
 
@@ -1079,23 +1081,6 @@ mod tests {
     let https_proxy = proxy_settings.for_url(&https_url);
     assert!(https_proxy.is_some());
 
-  }
-
-  #[test]
-  fn incorrect_host_url() {
-    let proxy = Proxy {
-      mode: Mode::Custom,
-      server: Some(Server::new(
-        String::from("http"),
-        String::from("proxy.example.com"),
-        Intercepts::HttpHttps
-      ))
-    };
-
-    match proxy.convert() {
-      Ok(_) => panic!("ProxySettings conversion should fail"),
-      Err(_) => ()
-    }
   }
 }
 

--- a/core/tauri/src/api/http.rs
+++ b/core/tauri/src/api/http.rs
@@ -822,7 +822,6 @@ struct Server {
   pub bypass: Vec<String>,
   pub password: Option<String>,
   pub username: Option<String>,
-  pub destination: Url,
 }
 
 impl Proxy {
@@ -847,25 +846,22 @@ impl Proxy {
         } else {
           self.server.port.unwrap_or(80)
         };
-        // Determine whether to intercept request
-        let scheme = self.server.destination.scheme();
-        if self.server.intercepts == *scheme {
-          // TODO: Error Handling
-          let mut url = Url::parse(&self.server.host)?;
-          url.set_port(Some(port))
-            .map_err(|_| crate::api::Error::Url(url::ParseError::InvalidPort))?;
+        // Build host URL
+        let mut host = Url::parse(&self.server.host)?;
+        host.set_port(Some(port))
+          .map_err(|_| crate::api::Error::Url(url::ParseError::InvalidPort))?;
 
-          match self.server.intercepts {
-            Intercepts::Http => {
-              settings = settings.http_proxy(url);
-            },
-            Intercepts::Https => {
-              settings = settings.https_proxy(url);
-            },
-            Intercepts::HttpHttps => {
-              settings = settings.http_proxy(url.clone());
-              settings = settings.https_proxy(url);
-            }
+        // Set proxies based on transport type
+        match self.server.intercepts {
+          Intercepts::Http => {
+            settings = settings.http_proxy(host);
+          },
+          Intercepts::Https => {
+            settings = settings.https_proxy(host);
+          },
+          Intercepts::HttpHttps => {
+            settings = settings.http_proxy(host.clone());
+            settings = settings.https_proxy(host);
           }
         }
         Ok(settings.build())
@@ -889,150 +885,150 @@ mod tests {
     assert_eq!(Intercepts::HttpHttps.eq("https"), true);
   }
 
-  #[test]
-  fn no_proxy() {
-    let proxy = Proxy {
-      mode: Mode::NoProxy,
-      server: Server {
-        protocol: String::from("http"),
-        host: String::from("http://proxy.example.com"),
-        port: None,
-        intercepts: Intercepts::Http,
-        bypass: vec![],
-        password: None,
-        username: None,
-        destination: Url::parse("http://example.com/dest").unwrap(),
-      },
-    };
+  // #[test]
+  // fn no_proxy() {
+  //   let proxy = Proxy {
+  //     mode: Mode::NoProxy,
+  //     server: Server {
+  //       protocol: String::from("http"),
+  //       host: String::from("http://proxy.example.com"),
+  //       port: None,
+  //       intercepts: Intercepts::Http,
+  //       bypass: vec![],
+  //       password: None,
+  //       username: None,
+  //       destination: Url::parse("http://example.com/dest").unwrap(),
+  //     },
+  //   };
 
-    let proxy_settings = proxy.convert().unwrap();
-    // No proxy server url's should be returned in this mode
-    assert!(proxy_settings.for_url(&proxy.server.destination).is_none());
-  }
+  //   let proxy_settings = proxy.convert().unwrap();
+  //   // No proxy server url's should be returned in this mode
+  //   assert!(proxy_settings.for_url(&proxy.server.destination).is_none());
+  // }
 
-  #[test]
-  fn http_proxy() {
-    let mut proxy = Proxy {
-      mode: Mode::Custom,
-      server: Server {
-          protocol: String::from("http"),
-          host: String::from("http://proxy.example.com"),
-          port: Some(8080),
-          intercepts: Intercepts::Http,
-          bypass: vec![],
-          password: None,
-          username: None,
-          destination: Url::parse("http://example.com/dest").unwrap(),
-      },
-    };
+  // #[test]
+  // fn http_proxy() {
+  //   let mut proxy = Proxy {
+  //     mode: Mode::Custom,
+  //     server: Server {
+  //         protocol: String::from("http"),
+  //         host: String::from("http://proxy.example.com"),
+  //         port: Some(8080),
+  //         intercepts: Intercepts::Http,
+  //         bypass: vec![],
+  //         password: None,
+  //         username: None,
+  //         destination: Url::parse("http://example.com/dest").unwrap(),
+  //     },
+  //   };
 
-    // HTTP destinations are proxied
-    let mut proxy_settings = proxy.convert().unwrap();
-    assert!(proxy_settings.for_url(&proxy.server.destination).is_some());
+  //   // HTTP destinations are proxied
+  //   let mut proxy_settings = proxy.convert().unwrap();
+  //   assert!(proxy_settings.for_url(&proxy.server.destination).is_some());
 
-    proxy.server.destination = Url::parse("https://google.com").unwrap();
-    proxy_settings = proxy.convert().unwrap();
-    assert!(proxy_settings.for_url(&proxy.server.destination).is_none());
-  }
+  //   proxy.server.destination = Url::parse("https://google.com").unwrap();
+  //   proxy_settings = proxy.convert().unwrap();
+  //   assert!(proxy_settings.for_url(&proxy.server.destination).is_none());
+  // }
 
-  #[test]
-  fn https_proxy() {
-    let mut proxy = Proxy {
-      mode: Mode::Custom,
-      server: Server {
-          protocol: String::from("http"),
-          host: String::from("http://proxy.example.com"),
-          port: Some(8080),
-          intercepts: Intercepts::Https,
-          destination: Url::parse("http://example.com/dest").unwrap(),
-          password: None,
-          username: None,
-          bypass: vec![]
-      },
-    };
+  // #[test]
+  // fn https_proxy() {
+  //   let mut proxy = Proxy {
+  //     mode: Mode::Custom,
+  //     server: Server {
+  //         protocol: String::from("http"),
+  //         host: String::from("http://proxy.example.com"),
+  //         port: Some(8080),
+  //         intercepts: Intercepts::Https,
+  //         destination: Url::parse("http://example.com/dest").unwrap(),
+  //         password: None,
+  //         username: None,
+  //         bypass: vec![]
+  //     },
+  //   };
 
-    // HTTP destinations not proxied
-    let mut proxy_settings = proxy.convert().unwrap();
-    assert!(proxy_settings.for_url(&proxy.server.destination).is_none());
+  //   // HTTP destinations not proxied
+  //   let mut proxy_settings = proxy.convert().unwrap();
+  //   assert!(proxy_settings.for_url(&proxy.server.destination).is_none());
 
-    proxy.server.destination = Url::parse("https://google.com").unwrap();
-    proxy_settings = proxy.convert().unwrap();
-    assert!(proxy_settings.for_url(&proxy.server.destination).is_some());
-  }
+  //   proxy.server.destination = Url::parse("https://google.com").unwrap();
+  //   proxy_settings = proxy.convert().unwrap();
+  //   assert!(proxy_settings.for_url(&proxy.server.destination).is_some());
+  // }
 
-  #[test]
-  fn http_https_proxy() {
-    let proxy = Proxy {
-      mode: Mode::Custom,
-      server: Server {
-          protocol: String::from("http"),
-          host: String::from("http://proxy.example.com"),
-          port: Some(8080),
-          intercepts: Intercepts::HttpHttps,
-          destination: Url::parse("http://example.com/dest").unwrap(),
-          password: None,
-          username: None,
-          bypass: vec![]
-      },
-    };
+  // #[test]
+  // fn http_https_proxy() {
+  //   let proxy = Proxy {
+  //     mode: Mode::Custom,
+  //     server: Server {
+  //         protocol: String::from("http"),
+  //         host: String::from("http://proxy.example.com"),
+  //         port: Some(8080),
+  //         intercepts: Intercepts::HttpHttps,
+  //         destination: Url::parse("http://example.com/dest").unwrap(),
+  //         password: None,
+  //         username: None,
+  //         bypass: vec![]
+  //     },
+  //   };
 
-    // Both are proxied
-    let proxy_settings = proxy.convert().unwrap();
-    assert!(proxy_settings.for_url(&proxy.server.destination).is_some());
-    let https_url = Url::parse("https://google.com").unwrap();
-    assert!(proxy_settings.for_url(&https_url).is_some());
-  }
+  //   // Both are proxied
+  //   let proxy_settings = proxy.convert().unwrap();
+  //   assert!(proxy_settings.for_url(&proxy.server.destination).is_some());
+  //   let https_url = Url::parse("https://google.com").unwrap();
+  //   assert!(proxy_settings.for_url(&https_url).is_some());
+  // }
 
-  #[test]
-  fn bypass_proxy() {
-    let proxy = Proxy {
-      mode: Mode::Custom,
-      server: Server {
-          protocol: String::from("http"),
-          host: String::from("http://proxy.example.com"),
-          port: Some(8080),
-          intercepts: Intercepts::HttpHttps,
-          destination: Url::parse("http://example.com/dest").unwrap(),
-          password: None,
-          username: None,
-          bypass: vec![String::from("localhost"), String::from("127.0.0.1")],
-      },
-    };
+  // #[test]
+  // fn bypass_proxy() {
+  //   let proxy = Proxy {
+  //     mode: Mode::Custom,
+  //     server: Server {
+  //         protocol: String::from("http"),
+  //         host: String::from("http://proxy.example.com"),
+  //         port: Some(8080),
+  //         intercepts: Intercepts::HttpHttps,
+  //         destination: Url::parse("http://example.com/dest").unwrap(),
+  //         password: None,
+  //         username: None,
+  //         bypass: vec![String::from("localhost"), String::from("127.0.0.1")],
+  //     },
+  //   };
 
-    let proxy_settings = proxy.convert().unwrap();
-    let bypass_url = Url::parse("http://localhost/dest").unwrap();
-    assert!(proxy_settings.for_url(&bypass_url).is_none());
+  //   let proxy_settings = proxy.convert().unwrap();
+  //   let bypass_url = Url::parse("http://localhost/dest").unwrap();
+  //   assert!(proxy_settings.for_url(&bypass_url).is_none());
 
-    let http_url = Url::parse("https://google.com").unwrap();
-    let http_proxy = proxy_settings.for_url(&http_url);
-    assert!(http_proxy.is_some());
+  //   let http_url = Url::parse("https://google.com").unwrap();
+  //   let http_proxy = proxy_settings.for_url(&http_url);
+  //   assert!(http_proxy.is_some());
 
-    let https_url = Url::parse("https://google.com").unwrap();
-    let https_proxy = proxy_settings.for_url(&https_url);
-    assert!(https_proxy.is_some());
+  //   let https_url = Url::parse("https://google.com").unwrap();
+  //   let https_proxy = proxy_settings.for_url(&https_url);
+  //   assert!(https_proxy.is_some());
 
-  }
+  // }
 
-  #[test]
-  fn incorrect_host_url() {
-    let proxy = Proxy {
-      mode: Mode::Custom,
-      server: Server {
-          protocol: String::from("http"),
-          host: String::from("proxy.example.com"),
-          port: Some(8080),
-          intercepts: Intercepts::HttpHttps,
-          destination: Url::parse("http://example.com/dest").unwrap(),
-          password: None,
-          username: None,
-          bypass: vec![String::from("localhost"), String::from("127.0.0.1")],
-      },
-    };
+  // #[test]
+  // fn incorrect_host_url() {
+  //   let proxy = Proxy {
+  //     mode: Mode::Custom,
+  //     server: Server {
+  //         protocol: String::from("http"),
+  //         host: String::from("proxy.example.com"),
+  //         port: Some(8080),
+  //         intercepts: Intercepts::HttpHttps,
+  //         destination: Url::parse("http://example.com/dest").unwrap(),
+  //         password: None,
+  //         username: None,
+  //         bypass: vec![String::from("localhost"), String::from("127.0.0.1")],
+  //     },
+  //   };
 
-    match proxy.convert() {
-      Ok(_) => panic!("ProxySettings conversion should fail"),
-      Err(_) => ()
-    }
-  }
+  //   match proxy.convert() {
+  //     Ok(_) => panic!("ProxySettings conversion should fail"),
+  //     Err(_) => ()
+  //   }
+  // }
 }
 

--- a/core/tauri/src/api/http.rs
+++ b/core/tauri/src/api/http.rs
@@ -163,6 +163,8 @@ impl Client {
       request_builder = request_builder.proxy_settings(settings);
     }
 
+    dbg!(&request_builder.inspect());
+
     let response = if let Some(body) = request.body {
       match body {
         Body::Bytes(data) => request_builder.body(attohttpc::body::Bytes(data)).danger_accept_invalid_certs(request.accept_invalid_certs.unwrap_or(false)).allow_compression(request.allow_compression.unwrap_or(true)).send()?,

--- a/core/tauri/src/api/http.rs
+++ b/core/tauri/src/api/http.rs
@@ -955,7 +955,6 @@ impl Proxy {
 #[cfg(test)]
 mod tests {
   use crate::api::http::*;
-  use url::Url;
 
   #[test]
   fn test_intercepts_eq() {
@@ -967,150 +966,125 @@ mod tests {
     assert_eq!(Intercepts::HttpHttps.eq("https"), true);
   }
 
-  // #[test]
-  // fn no_proxy() {
-  //   let proxy = Proxy {
-  //     mode: Mode::NoProxy,
-  //     server: Server {
-  //       protocol: String::from("http"),
-  //       host: String::from("http://proxy.example.com"),
-  //       port: None,
-  //       intercepts: Intercepts::Http,
-  //       bypass: vec![],
-  //       password: None,
-  //       username: None,
-  //       destination: Url::parse("http://example.com/dest").unwrap(),
-  //     },
-  //   };
+  #[test]
+  fn no_proxy() {
+    let proxy = Proxy {
+      mode: Mode::NoProxy,
+      server: Server::new(
+        String::from("http"),
+        String::from("http://proxy.example.com"),
+        Intercepts::Http
+      )
+    };
 
-  //   let proxy_settings = proxy.convert().unwrap();
-  //   // No proxy server url's should be returned in this mode
-  //   assert!(proxy_settings.for_url(&proxy.server.destination).is_none());
-  // }
+    let proxy_settings = proxy.convert().unwrap();
+    let destination = Url::parse("http://example.com/dest").unwrap();
+    // No proxy server url's should be returned in this mode
+    assert!(proxy_settings.for_url(&destination).is_none());
+  }
 
-  // #[test]
-  // fn http_proxy() {
-  //   let mut proxy = Proxy {
-  //     mode: Mode::Custom,
-  //     server: Server {
-  //         protocol: String::from("http"),
-  //         host: String::from("http://proxy.example.com"),
-  //         port: Some(8080),
-  //         intercepts: Intercepts::Http,
-  //         bypass: vec![],
-  //         password: None,
-  //         username: None,
-  //         destination: Url::parse("http://example.com/dest").unwrap(),
-  //     },
-  //   };
+  #[test]
+  fn http_proxy() {
+    let proxy = Proxy {
+      mode: Mode::Custom,
+      server: Server::new(
+        String::from("http"),
+        String::from("http://proxy.example.com"),
+        Intercepts::Http
+      )
+    };
 
-  //   // HTTP destinations are proxied
-  //   let mut proxy_settings = proxy.convert().unwrap();
-  //   assert!(proxy_settings.for_url(&proxy.server.destination).is_some());
+    // HTTP destinations are proxied
+    let mut proxy_settings = proxy.convert().unwrap();
+    let mut destination = Url::parse("http://example.com/dest").unwrap();
+    assert!(proxy_settings.for_url(&destination).is_some());
 
-  //   proxy.server.destination = Url::parse("https://google.com").unwrap();
-  //   proxy_settings = proxy.convert().unwrap();
-  //   assert!(proxy_settings.for_url(&proxy.server.destination).is_none());
-  // }
+    destination = Url::parse("https://google.com").unwrap();
+    proxy_settings = proxy.convert().unwrap();
+    assert!(proxy_settings.for_url(&destination).is_none());
+  }
 
-  // #[test]
-  // fn https_proxy() {
-  //   let mut proxy = Proxy {
-  //     mode: Mode::Custom,
-  //     server: Server {
-  //         protocol: String::from("http"),
-  //         host: String::from("http://proxy.example.com"),
-  //         port: Some(8080),
-  //         intercepts: Intercepts::Https,
-  //         destination: Url::parse("http://example.com/dest").unwrap(),
-  //         password: None,
-  //         username: None,
-  //         bypass: vec![]
-  //     },
-  //   };
+  #[test]
+  fn https_proxy() {
+    let proxy = Proxy {
+      mode: Mode::Custom,
+      server: Server::new(
+        String::from("http"),
+        String::from("http://proxy.example.com"),
+        Intercepts::Https
+      )
+    };
 
-  //   // HTTP destinations not proxied
-  //   let mut proxy_settings = proxy.convert().unwrap();
-  //   assert!(proxy_settings.for_url(&proxy.server.destination).is_none());
+    // HTTP destinations not proxied
+    let mut proxy_settings = proxy.convert().unwrap();
+    let mut destination = Url::parse("http://example.com/dest").unwrap();
+    assert!(proxy_settings.for_url(&destination).is_none());
 
-  //   proxy.server.destination = Url::parse("https://google.com").unwrap();
-  //   proxy_settings = proxy.convert().unwrap();
-  //   assert!(proxy_settings.for_url(&proxy.server.destination).is_some());
-  // }
+    destination = Url::parse("https://google.com").unwrap();
+    proxy_settings = proxy.convert().unwrap();
+    assert!(proxy_settings.for_url(&destination).is_some());
+  }
 
-  // #[test]
-  // fn http_https_proxy() {
-  //   let proxy = Proxy {
-  //     mode: Mode::Custom,
-  //     server: Server {
-  //         protocol: String::from("http"),
-  //         host: String::from("http://proxy.example.com"),
-  //         port: Some(8080),
-  //         intercepts: Intercepts::HttpHttps,
-  //         destination: Url::parse("http://example.com/dest").unwrap(),
-  //         password: None,
-  //         username: None,
-  //         bypass: vec![]
-  //     },
-  //   };
+  #[test]
+  fn http_https_proxy() {
+    let proxy = Proxy {
+      mode: Mode::Custom,
+      server: Server::new(
+        String::from("http"),
+        String::from("http://proxy.example.com"),
+        Intercepts::HttpHttps
+      )
+    };
 
-  //   // Both are proxied
-  //   let proxy_settings = proxy.convert().unwrap();
-  //   assert!(proxy_settings.for_url(&proxy.server.destination).is_some());
-  //   let https_url = Url::parse("https://google.com").unwrap();
-  //   assert!(proxy_settings.for_url(&https_url).is_some());
-  // }
+    // Both are proxied
+    let proxy_settings = proxy.convert().unwrap();
+    let http_url = Url::parse("http://example.com/dest").unwrap();
+    assert!(proxy_settings.for_url(&http_url).is_some());
+    let https_url = Url::parse("https://google.com").unwrap();
+    assert!(proxy_settings.for_url(&https_url).is_some());
+  }
 
-  // #[test]
-  // fn bypass_proxy() {
-  //   let proxy = Proxy {
-  //     mode: Mode::Custom,
-  //     server: Server {
-  //         protocol: String::from("http"),
-  //         host: String::from("http://proxy.example.com"),
-  //         port: Some(8080),
-  //         intercepts: Intercepts::HttpHttps,
-  //         destination: Url::parse("http://example.com/dest").unwrap(),
-  //         password: None,
-  //         username: None,
-  //         bypass: vec![String::from("localhost"), String::from("127.0.0.1")],
-  //     },
-  //   };
+  #[test]
+  fn bypass_proxy() {
+    let mut proxy = Proxy {
+      mode: Mode::Custom,
+      server: Server::new(
+        String::from("http"),
+        String::from("http://proxy.example.com"),
+        Intercepts::HttpHttps
+      )
+    };
+    proxy.server.add_bypass_url(String::from("localhost"));
 
-  //   let proxy_settings = proxy.convert().unwrap();
-  //   let bypass_url = Url::parse("http://localhost/dest").unwrap();
-  //   assert!(proxy_settings.for_url(&bypass_url).is_none());
+    let proxy_settings = proxy.convert().unwrap();
+    let bypass_url = Url::parse("http://localhost/dest").unwrap();
+    assert!(proxy_settings.for_url(&bypass_url).is_none());
 
-  //   let http_url = Url::parse("https://google.com").unwrap();
-  //   let http_proxy = proxy_settings.for_url(&http_url);
-  //   assert!(http_proxy.is_some());
+    let http_url = Url::parse("https://google.com").unwrap();
+    let http_proxy = proxy_settings.for_url(&http_url);
+    assert!(http_proxy.is_some());
 
-  //   let https_url = Url::parse("https://google.com").unwrap();
-  //   let https_proxy = proxy_settings.for_url(&https_url);
-  //   assert!(https_proxy.is_some());
+    let https_url = Url::parse("https://google.com").unwrap();
+    let https_proxy = proxy_settings.for_url(&https_url);
+    assert!(https_proxy.is_some());
 
-  // }
+  }
 
-  // #[test]
-  // fn incorrect_host_url() {
-  //   let proxy = Proxy {
-  //     mode: Mode::Custom,
-  //     server: Server {
-  //         protocol: String::from("http"),
-  //         host: String::from("proxy.example.com"),
-  //         port: Some(8080),
-  //         intercepts: Intercepts::HttpHttps,
-  //         destination: Url::parse("http://example.com/dest").unwrap(),
-  //         password: None,
-  //         username: None,
-  //         bypass: vec![String::from("localhost"), String::from("127.0.0.1")],
-  //     },
-  //   };
+  #[test]
+  fn incorrect_host_url() {
+    let proxy = Proxy {
+      mode: Mode::Custom,
+      server: Server::new(
+        String::from("http"),
+        String::from("proxy.example.com"),
+        Intercepts::HttpHttps
+      )
+    };
 
-  //   match proxy.convert() {
-  //     Ok(_) => panic!("ProxySettings conversion should fail"),
-  //     Err(_) => ()
-  //   }
-  // }
+    match proxy.convert() {
+      Ok(_) => panic!("ProxySettings conversion should fail"),
+      Err(_) => ()
+    }
+  }
 }
 

--- a/core/tauri/src/api/http.rs
+++ b/core/tauri/src/api/http.rs
@@ -163,8 +163,6 @@ impl Client {
       request_builder = request_builder.proxy_settings(settings);
     }
 
-    dbg!(&request_builder.inspect().url());
-
     let response = if let Some(body) = request.body {
       match body {
         Body::Bytes(data) => request_builder.body(attohttpc::body::Bytes(data)).danger_accept_invalid_certs(request.accept_invalid_certs.unwrap_or(false)).allow_compression(request.allow_compression.unwrap_or(true)).send()?,
@@ -991,7 +989,7 @@ impl Proxy {
           }
           host.set_password(server.password.as_deref())
             .map_err(|_| crate::api::Error::Auth)?;
-
+          dbg!("Proxy URL", &host.as_str());
           // Set proxies based on transport type
           match server.intercepts {
             Intercepts::Http => {

--- a/core/tauri/src/api/http.rs
+++ b/core/tauri/src/api/http.rs
@@ -162,7 +162,9 @@ impl Client {
     if let Some(proxy) = request.proxy {
       request_builder = request_builder.proxy_settings(proxy.convert()?);
       // Check if any credentials exist
-      if let Some(credentials) = proxy.base64_credentials() {
+      let creds = proxy.base64_credentials();
+      dbg!(&creds);
+      if let Some(credentials) = creds {
         // Add the credentials to the Proxy-Authorization header if it doesn't already exist
         if request.headers.is_none() || request.headers.as_ref().map_or(false, |h| h.0.contains_key("Proxy-Authorization")) {
           request_builder = request_builder.header_append("Proxy-Authorization", format!("Basic {credentials}"))
@@ -1048,9 +1050,15 @@ mod tests {
 
   #[test]
   fn proxy_request() {
-    let client = ClientBuilder::new().build().unwrap();
-    let request = HttpRequestBuilder::new("GET", "http://example.com").unwrap();
+    // let client = ClientBuilder::new().build().unwrap();
+    // let request = HttpRequestBuilder::new("GET", "http://example.com").unwrap();
+    // let mut server = Server::new(
+    //   String::from("http"),
+    //   String::from("localhost"),
+    //   Intercepts::HttpHttps
+    // );
   }
+  // server.set_port
 
   #[test]
   fn test_intercepts_eq() {

--- a/core/tauri/src/api/http.rs
+++ b/core/tauri/src/api/http.rs
@@ -909,9 +909,7 @@ impl Server {
 /// ```
 macro_rules! env_proxy_settings {
   ($env_var:expr, $settings:expr, [ $($method:ident),+ ]) => {
-      println!("Parsing env var: {}", $env_var);
       if let Ok(url_str) = std::env::var($env_var) {
-        println!("Value: {}", url_str);
           let url = url::Url::parse(&url_str)?;
           $(
               $settings = $settings.$method(url.clone());

--- a/core/tauri/src/api/http.rs
+++ b/core/tauri/src/api/http.rs
@@ -907,6 +907,7 @@ impl Server {
   }
 }
 
+
 impl Proxy {
   /// Handle frontend proxy logic and convert to a attohttpc ProxySettings struct
   /// NO_PROXY -> Set attohttpc to disable proxying
@@ -915,7 +916,12 @@ impl Proxy {
   fn convert(&self) -> crate::api::Result<ProxySettings>  {
     match self.mode {
       Mode::NoProxy => Ok(ProxySettings::builder().build()),
-      Mode::Env => Ok(ProxySettings::from_env()),
+      Mode::Env => {
+        println!("{:?}", std::env::var("HTTP_PROXY"));
+        Ok(
+          ProxySettings::from_env()
+        )
+      }
       Mode::Custom => {
         let mut settings = ProxySettings::builder();
         if let Some(server) = &self.server {

--- a/core/tauri/src/api/http.rs
+++ b/core/tauri/src/api/http.rs
@@ -841,7 +841,7 @@ pub struct Server {
   /// Traffic types to pass to the proxy
   pub intercepts: Intercepts,
   /// List of urls to bypass
-  pub bypass: Vec<String>,
+  pub bypass: Option<Vec<String>>,
   /// Proxy auth username
   pub username: Option<String>,
   ///. Proxy auth password
@@ -902,7 +902,10 @@ impl Server {
   /// # assert!(server.bypass.len() > 0);
   /// ```
   pub fn add_bypass_url(&mut self, url: String) {
-    self.bypass.push(url);
+    match self.bypass {
+      Some(ref mut bypass) => bypass.push(url),
+      None => self.bypass = Some(vec![url])
+    }
   }
 
   /// Sets the proxy server username and password
@@ -934,8 +937,10 @@ impl Proxy {
         let mut settings = ProxySettings::builder();
         if let Some(server) = &self.server {
           // Add any hosts to bypass proxy server
-          for bypass_host in server.bypass.clone() {
-            settings = settings.add_no_proxy_host(bypass_host);
+          if let Some(bypass) = server.bypass.clone() {
+            for bypass_host in bypass.clone() {
+              settings = settings.add_no_proxy_host(bypass_host);
+            }
           }
           // Set port if it exists otherwise use protocol default
           let port = if server.protocol.eq_ignore_ascii_case("https") {

--- a/core/tauri/src/api/http.rs
+++ b/core/tauri/src/api/http.rs
@@ -939,6 +939,7 @@ impl Proxy {
           }
         }
 
+        env_proxy_settings!("all_proxy", settings, [ http_proxy, https_proxy ]);
         env_proxy_settings!("ALL_PROXY", settings, [ http_proxy, https_proxy ]);
         env_proxy_settings!("http_proxy", settings, [ http_proxy ]);
         env_proxy_settings!("https_proxy", settings, [ https_proxy ]);

--- a/core/tauri/src/api/http.rs
+++ b/core/tauri/src/api/http.rs
@@ -169,7 +169,7 @@ impl Client {
         }
       }
     }
-
+    dbg!(&request.headers);
     let response = if let Some(body) = request.body {
       match body {
         Body::Bytes(data) => request_builder.body(attohttpc::body::Bytes(data)).danger_accept_invalid_certs(request.accept_invalid_certs.unwrap_or(false)).allow_compression(request.allow_compression.unwrap_or(true)).send()?,
@@ -1001,11 +1001,6 @@ impl Proxy {
       let mut host = Url::parse(&proxy_url)?;
       host.set_port(Some(port))
         .map_err(|_| crate::api::Error::Url(url::ParseError::InvalidPort))?;
-
-      if let Some(username) = &server.username {
-        host.set_username(&username).map_err(|_| crate::api::Error::Auth)?;
-      }
-      host.set_password(server.password.as_deref()).map_err(|_| crate::api::Error::Auth)?;
 
       // Set proxies based on transport type
       match server.intercepts {

--- a/core/tauri/src/api/http.rs
+++ b/core/tauri/src/api/http.rs
@@ -891,23 +891,6 @@ impl Server {
     self.port = None;
   }
 
-  // /// Adds a url to the bypass list
-  // ///
-  // /// # Example
-  // ///
-  // /// ```
-  // /// # use tauri::api::http::{Server, Intercepts};
-  // /// # let mut server = Server::new("https".to_string(), "https://proxy.example.com".to_string() , Intercepts::Http);
-  // /// server.add_bypass_url("https://www.google.com".to_string());
-  // /// # assert!(server.bypass.len() > 0);
-  // /// ```
-  // pub fn add_bypass_url(&mut self, url: String) {
-  //   match self.bypass {
-  //     Some(ref mut bypass) => bypass.extend(url),
-  //     None => self.bypass = Some(vec![url])
-  //   }
-  // }
-
   /// Sets the proxy server username and password
   ///
   /// # Example
@@ -1063,32 +1046,5 @@ mod tests {
     let https_url = Url::parse("https://google.com").unwrap();
     assert!(proxy_settings.for_url(&https_url).is_some());
   }
-
-//   #[test]
-//   fn bypass_proxy() {
-//     let mut proxy = Proxy {
-//       mode: Mode::Custom,
-//       server: Some(Server::new(
-//         String::from("http"),
-//         String::from("http://proxy.example.com"),
-//         Intercepts::HttpHttps,
-//       ))
-//     };
-//     if let Some(ref mut server) = proxy.server {
-//       server.add_bypass_url();
-//     }
-//     let proxy_settings = proxy.convert().unwrap();
-//     let bypass_url = Url::parse("http://localhost/dest").unwrap();
-//     assert!(proxy_settings.for_url(&bypass_url).is_none());
-
-//     let http_url = Url::parse("https://google.com").unwrap();
-//     let http_proxy = proxy_settings.for_url(&http_url);
-//     assert!(http_proxy.is_some());
-
-//     let https_url = Url::parse("https://google.com").unwrap();
-//     let https_proxy = proxy_settings.for_url(&https_url);
-//     assert!(https_proxy.is_some());
-
-//   }
 }
 

--- a/core/tauri/src/api/http.rs
+++ b/core/tauri/src/api/http.rs
@@ -949,9 +949,8 @@ impl Proxy {
             server.port.unwrap_or(80)
           };
           // Build host URL
-          let mut host = Url::parse(&server.host)?;
-          host.set_scheme(&server.protocol)
-            .map_err(|_| crate::api::Error::Url(url::ParseError::EmptyHost))?;
+          let proxy_url = format!("{}://{}", server.protocol, &server.host);
+          let mut host = Url::parse(&proxy_url)?;
           host.set_port(Some(port))
             .map_err(|_| crate::api::Error::Url(url::ParseError::InvalidPort))?;
 

--- a/core/tauri/src/api/http.rs
+++ b/core/tauri/src/api/http.rs
@@ -935,9 +935,18 @@ impl Proxy {
       },
       Mode::Env => {
         let mut settings = ProxySettings::builder();
-        if let Ok(disable) = env::var("NO_PROXY") {
+        if let Ok(disable) = env::var("no_proxy") {
           if disable == "*" {
             return Ok(settings.build())
+          } else {
+            for bypass_host in disable.split(",") {
+              settings = settings.add_no_proxy_host(bypass_host);
+            }
+          }
+        } else if let Ok(disable) = env::var("NO_PROXY") {
+          if disable == "*" {
+            // Return no_proxy settings
+            return Ok(ProxySettings::builder().build())
           } else {
             for bypass_host in disable.split(",") {
               settings = settings.add_no_proxy_host(bypass_host);

--- a/core/tauri/src/api/http.rs
+++ b/core/tauri/src/api/http.rs
@@ -161,20 +161,6 @@ impl Client {
     if let Some(proxy) = request.proxy {
       let settings = proxy.convert()?;
       request_builder = request_builder.proxy_settings(settings);
-
-      // Add Proxy auth headers if they don't already exist
-      if let Some(headers) = &request.headers {
-        if !headers.0.contains_key("Proxy-Authorization") {
-          if let Some(server) = proxy.server {
-            // Assumes password exists if username exists
-            if let Some(username) = server.username {
-              let password = server.password.unwrap_or("".to_string());
-              let credentials = base64::encode(format!("{username}:{password}"));
-              request_builder = request_builder.header_append("Proxy-Authorization", format!("Basic {credentials}"))
-            }
-          }
-        }
-      }
     }
 
     let response = if let Some(body) = request.body {

--- a/core/tauri/src/api/http.rs
+++ b/core/tauri/src/api/http.rs
@@ -798,10 +798,13 @@ impl Default for Mode {
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub enum Intercepts {
   /// HTTP Only
+  #[serde(rename = "HTTP")]
   Http,
   /// HTTPS Only
+  #[serde(rename = "HTTPS")]
   Https,
   /// Both HTTPS and HTTP
+  #[serde(rename = "HTTP_HTTPS")]
   HttpHttps
 }
 

--- a/core/tauri/src/api/http.rs
+++ b/core/tauri/src/api/http.rs
@@ -170,6 +170,7 @@ impl Client {
       }
     }
     dbg!(&request.headers);
+
     let response = if let Some(body) = request.body {
       match body {
         Body::Bytes(data) => request_builder.body(attohttpc::body::Bytes(data)).danger_accept_invalid_certs(request.accept_invalid_certs.unwrap_or(false)).allow_compression(request.allow_compression.unwrap_or(true)).send()?,
@@ -967,7 +968,7 @@ impl Proxy {
     Ok(settings.build())
   }
 
-  ///
+  /// Custom proxy configuation
   fn custom(&self) -> crate::api::Result<ProxySettings> {
     let mut settings = ProxySettings::builder();
     if let Some(server) = &self.server {
@@ -1024,6 +1025,7 @@ impl Proxy {
   /// Returns the credentials formatted for Basic Auth in base64
   /// eg. user:pass
   pub fn base64_credentials(&self) -> Option<String> {
+    dbg!("base64_credentials", &self);
     if let Some(server) = self.server.clone() {
       if let Some(username) = server.username {
         let password = &server.password.unwrap_or("".to_string());
@@ -1043,6 +1045,12 @@ impl Proxy {
 #[cfg(test)]
 mod tests {
   use crate::api::http::*;
+
+  #[test]
+  fn proxy_request() {
+    let client = ClientBuilder::new().build().unwrap();
+    let request = HttpRequestBuilder::new("GET", "http://example.com").unwrap();
+  }
 
   #[test]
   fn test_intercepts_eq() {

--- a/core/tauri/src/api/http.rs
+++ b/core/tauri/src/api/http.rs
@@ -160,7 +160,6 @@ impl Client {
 
     if let Some(proxy) = request.proxy {
       let settings = proxy.convert()?;
-      dbg!(&settings);
       request_builder = request_builder.proxy_settings(settings);
       // Add Proxy auth headers if they don't already exist
       if let Some(credentials) = proxy.base64_credentials() {
@@ -169,7 +168,6 @@ impl Client {
         }
       }
     }
-
 
     let response = if let Some(body) = request.body {
       match body {
@@ -931,7 +929,6 @@ impl Proxy {
     match self.mode {
       Mode::NoProxy => {
         let settings = ProxySettings::builder();
-        dbg!(&settings);
         Ok(settings.build())
       },
       Mode::Env => {
@@ -955,7 +952,6 @@ impl Proxy {
         env_proxy_settings!("http_proxy", settings, [ http_proxy, https_proxy ]);
         env_proxy_settings!("HTTPS_PROXY", settings, [ https_proxy ]);
         env_proxy_settings!("https_proxy", settings, [ https_proxy ]);
-        dbg!(&settings);
         Ok(settings.build())
        },
       Mode::Custom => {
@@ -991,7 +987,6 @@ impl Proxy {
           host.set_port(Some(port))
             .map_err(|_| crate::api::Error::Url(url::ParseError::InvalidPort))?;
 
-          dbg!("Proxy URL", &host.as_str());
           // Set proxies based on transport type
           match server.intercepts {
             Intercepts::Http => {
@@ -1005,7 +1000,6 @@ impl Proxy {
               settings = settings.https_proxy(host);
             }
           }
-          dbg!(&settings);
           Ok(settings.build())
         } else {
           Err(crate::api::Error::ProxyServer)
@@ -1247,7 +1241,7 @@ mod tests {
     );
     server.username = Some("user".to_string());
     server.password = Some("pass".to_string());
-    let mut proxy = Proxy {
+    let proxy = Proxy {
       mode: Mode::Custom,
       server: Some(server)
     };

--- a/core/tauri/src/api/http.rs
+++ b/core/tauri/src/api/http.rs
@@ -988,6 +988,7 @@ impl Proxy {
           server_port = None;
         }
       }
+
       // Use defaults if port not set
       let port = if server.protocol.eq_ignore_ascii_case("https") {
         server_port.unwrap_or(443)
@@ -1002,11 +1003,9 @@ impl Proxy {
         .map_err(|_| crate::api::Error::Url(url::ParseError::InvalidPort))?;
 
       if let Some(username) = &server.username {
-        host.set_username(&username)
-          .map_err(|_| crate::api::Error::Auth)?;
+        host.set_username(&username).map_err(|_| crate::api::Error::Auth)?;
       }
-      host.set_password(server.password.as_deref())
-        .map_err(|_| crate::api::Error::Auth)?;
+      host.set_password(server.password.as_deref()).map_err(|_| crate::api::Error::Auth)?;
 
       // Set proxies based on transport type
       match server.intercepts {

--- a/core/tauri/src/api/http.rs
+++ b/core/tauri/src/api/http.rs
@@ -841,7 +841,7 @@ pub struct Server {
   /// Traffic types to pass to the proxy
   pub intercepts: Intercepts,
   /// List of urls to bypass
-  pub bypass: Option<Vec<String>>,
+  pub bypass: Option<String>,
   /// Proxy auth username
   pub username: Option<String>,
   ///. Proxy auth password
@@ -891,22 +891,22 @@ impl Server {
     self.port = None;
   }
 
-  /// Adds a url to the bypass list
-  ///
-  /// # Example
-  ///
-  /// ```
-  /// # use tauri::api::http::{Server, Intercepts};
-  /// # let mut server = Server::new("https".to_string(), "https://proxy.example.com".to_string() , Intercepts::Http);
-  /// server.add_bypass_url("https://www.google.com".to_string());
-  /// # assert!(server.bypass.len() > 0);
-  /// ```
-  pub fn add_bypass_url(&mut self, url: String) {
-    match self.bypass {
-      Some(ref mut bypass) => bypass.push(url),
-      None => self.bypass = Some(vec![url])
-    }
-  }
+  // /// Adds a url to the bypass list
+  // ///
+  // /// # Example
+  // ///
+  // /// ```
+  // /// # use tauri::api::http::{Server, Intercepts};
+  // /// # let mut server = Server::new("https".to_string(), "https://proxy.example.com".to_string() , Intercepts::Http);
+  // /// server.add_bypass_url("https://www.google.com".to_string());
+  // /// # assert!(server.bypass.len() > 0);
+  // /// ```
+  // pub fn add_bypass_url(&mut self, url: String) {
+  //   match self.bypass {
+  //     Some(ref mut bypass) => bypass.extend(url),
+  //     None => self.bypass = Some(vec![url])
+  //   }
+  // }
 
   /// Sets the proxy server username and password
   ///
@@ -938,7 +938,7 @@ impl Proxy {
         if let Some(server) = &self.server {
           // Add any hosts to bypass proxy server
           if let Some(bypass) = server.bypass.clone() {
-            for bypass_host in bypass.clone() {
+            for bypass_host in bypass.split(",") {
               settings = settings.add_no_proxy_host(bypass_host);
             }
           }
@@ -1065,31 +1065,31 @@ mod tests {
     assert!(proxy_settings.for_url(&https_url).is_some());
   }
 
-  #[test]
-  fn bypass_proxy() {
-    let mut proxy = Proxy {
-      mode: Mode::Custom,
-      server: Some(Server::new(
-        String::from("http"),
-        String::from("http://proxy.example.com"),
-        Intercepts::HttpHttps
-      ))
-    };
-    if let Some(ref mut server) = proxy.server {
-      server.add_bypass_url(String::from("localhost"));
-    }
-    let proxy_settings = proxy.convert().unwrap();
-    let bypass_url = Url::parse("http://localhost/dest").unwrap();
-    assert!(proxy_settings.for_url(&bypass_url).is_none());
+//   #[test]
+//   fn bypass_proxy() {
+//     let mut proxy = Proxy {
+//       mode: Mode::Custom,
+//       server: Some(Server::new(
+//         String::from("http"),
+//         String::from("http://proxy.example.com"),
+//         Intercepts::HttpHttps,
+//       ))
+//     };
+//     if let Some(ref mut server) = proxy.server {
+//       server.add_bypass_url();
+//     }
+//     let proxy_settings = proxy.convert().unwrap();
+//     let bypass_url = Url::parse("http://localhost/dest").unwrap();
+//     assert!(proxy_settings.for_url(&bypass_url).is_none());
 
-    let http_url = Url::parse("https://google.com").unwrap();
-    let http_proxy = proxy_settings.for_url(&http_url);
-    assert!(http_proxy.is_some());
+//     let http_url = Url::parse("https://google.com").unwrap();
+//     let http_proxy = proxy_settings.for_url(&http_url);
+//     assert!(http_proxy.is_some());
 
-    let https_url = Url::parse("https://google.com").unwrap();
-    let https_proxy = proxy_settings.for_url(&https_url);
-    assert!(https_proxy.is_some());
+//     let https_url = Url::parse("https://google.com").unwrap();
+//     let https_proxy = proxy_settings.for_url(&https_url);
+//     assert!(https_proxy.is_some());
 
-  }
+//   }
 }
 

--- a/core/tauri/src/api/http.rs
+++ b/core/tauri/src/api/http.rs
@@ -166,8 +166,10 @@ impl Client {
       dbg!(&creds);
       if let Some(credentials) = creds {
         // Add the credentials to the Proxy-Authorization header if it doesn't already exist
-        if request.headers.is_none() || request.headers.as_ref().map_or(false, |h| h.0.contains_key("Proxy-Authorization")) {
-          request_builder = request_builder.header_append("Proxy-Authorization", format!("Basic {credentials}"))
+        if let Some(headers) = &request.headers {
+          if !headers.0.contains_key("Proxy-Authorization") {
+            request_builder = request_builder.header_append("Proxy-Authorization", format!("Basic {credentials}"))
+          }
         }
       }
     }

--- a/core/tauri/src/api/http.rs
+++ b/core/tauri/src/api/http.rs
@@ -782,10 +782,13 @@ pub struct Proxy {
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub enum Mode {
   /// Do not proxy any requests
+  #[serde(rename = "NO_PROXY")]
   NoProxy,
   /// Load environmental variables
+  #[serde(rename = "ENV")]
   Env,
   /// Custom proxy server
+  #[serde(rename = "CUSTOM")]
   Custom
 }
 


### PR DESCRIPTION
Adds a proxy field which parses the front end settings and configures the ProxyBuilder settings for attohttpc.
Default ports for http/https are used unless specified, any hosts in the bypass field are not proxied.
Uses Proxy-Authorization header for auth if username and password is set. 